### PR TITLE
fix: match theme toggle and github icon order on resume page

### DIFF
--- a/src/app/[locale]/resume/page.tsx
+++ b/src/app/[locale]/resume/page.tsx
@@ -34,8 +34,8 @@ export default function ResumePage() {
       <div className="fixed right-3 top-[max(0.75rem,env(safe-area-inset-top))] z-30 flex items-center gap-1.5 rounded-2xl border border-black/10 bg-white/82 p-1.5 shadow-[0_12px_32px_rgba(0,0,0,0.12)] backdrop-blur-md dark:border-white/10 dark:bg-[#111111]/86 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:p-0 sm:shadow-none">
         <ExportPdfButton />
         <LanguageSwitcher />
-        <GithubLink repoUrl="https://github.com/CUinspace233/my-resume" size="responsive" />
         <ThemeToggle />
+        <GithubLink repoUrl="https://github.com/CUinspace233/my-resume" size="responsive" />
       </div>
 
       <ScalableContent baseWidth={793} mobileBreakpoint={768}>


### PR DESCRIPTION
## Summary

- Swapped the order of `ThemeToggle` and `GithubLink` in the resume page header to match the main page

## What changed

On the resume page (`src/app/[locale]/resume/page.tsx`), the GitHub icon was appearing before the theme toggle, while the main page (`SiteNav.tsx`) had the opposite order: theme toggle first, then GitHub icon. This inconsistency made the UI feel misaligned.

**Before:** ExportPdfButton → LanguageSwitcher → GithubLink → ThemeToggle  
**After:** ExportPdfButton → LanguageSwitcher → ThemeToggle → GithubLink

## Reviewer notes

Purely cosmetic one-line change — no logic affected.