### PR TITLE
feat: display past-year contributions count above GitHub chart

### DIFF
--- a/src/components/landing/ContributionsChart.tsx
+++ b/src/components/landing/ContributionsChart.tsx
@@ -1,46 +1,25 @@
-'use client';
+import ContributionsChartClient from './ContributionsChartClient';
 
-import { useEffect, useRef } from 'react';
+async function fetchContributionsCount(): Promise<number | null> {
+  try {
+    const res = await fetch('https://github.com/users/CUinspace233/contributions', {
+      headers: {
+        Accept: 'text/html',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    const html = await res.text();
+    const matches = [...html.matchAll(/data-count="(\d+)"/g)];
+    const total = matches.reduce((sum, m) => sum + parseInt(m[1], 10), 0);
+    return total > 0 ? total : null;
+  } catch {
+    return null;
+  }
+}
 
-export default function ContributionsChart() {
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const scrollToRight = () => {
-      el.scrollLeft = el.scrollWidth - el.clientWidth;
-    };
-
-    scrollToRight();
-    window.addEventListener('resize', scrollToRight);
-    return () => window.removeEventListener('resize', scrollToRight);
-  }, []);
-
-  return (
-    <section
-      className="px-6 py-16 max-w-[1200px] mx-auto"
-      style={{ borderTop: '1px solid #ebebeb' }}
-    >
-      <p
-        className="font-[family-name:var(--font-geist-mono)] text-[11px] font-medium uppercase tracking-widest mb-6"
-        style={{ color: '#808080' }}
-      >
-        GitHub Contributions
-      </p>
-      <div
-        ref={scrollRef}
-        className="p-4 rounded-lg overflow-x-auto"
-        style={{ boxShadow: 'var(--card-shadow)' }}
-      >
-        <img
-          src="https://ghchart.rshah.org/0a72ef/CUinspace233"
-          alt="GitHub contribution chart for CUinspace233"
-          className="w-full min-w-[600px]"
-          style={{ imageRendering: 'crisp-edges' }}
-        />
-      </div>
-    </section>
-  );
+export default async function ContributionsChart() {
+  const count = await fetchContributionsCount();
+  return <ContributionsChartClient contributionsCount={count} />;
 }

--- a/src/components/landing/ContributionsChartClient.tsx
+++ b/src/components/landing/ContributionsChartClient.tsx
@@ -39,13 +39,10 @@ export default function ContributionsChartClient({ contributionsCount }: Props) 
             className="font-[family-name:var(--font-geist-mono)] text-[11px]"
             style={{ color: '#808080' }}
           >
-            <span
-              className="font-bold text-sm"
-              style={{ color: '#0a72ef' }}
-            >
+            <span className="font-bold text-sm" style={{ color: '#0a72ef' }}>
               {contributionsCount.toLocaleString()}
-            </span>
-            {' '}contributions in the last year
+            </span>{' '}
+            contributions in the last year
           </p>
         )}
       </div>

--- a/src/components/landing/ContributionsChartClient.tsx
+++ b/src/components/landing/ContributionsChartClient.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  contributionsCount: number | null;
+}
+
+export default function ContributionsChartClient({ contributionsCount }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const scrollToRight = () => {
+      el.scrollLeft = el.scrollWidth - el.clientWidth;
+    };
+
+    scrollToRight();
+    window.addEventListener('resize', scrollToRight);
+    return () => window.removeEventListener('resize', scrollToRight);
+  }, []);
+
+  return (
+    <section
+      className="px-6 py-16 max-w-[1200px] mx-auto"
+      style={{ borderTop: '1px solid #ebebeb' }}
+    >
+      <div className="flex items-baseline justify-between mb-6">
+        <p
+          className="font-[family-name:var(--font-geist-mono)] text-[11px] font-medium uppercase tracking-widest"
+          style={{ color: '#808080' }}
+        >
+          GitHub Contributions
+        </p>
+        {contributionsCount !== null && (
+          <p
+            className="font-[family-name:var(--font-geist-mono)] text-[11px]"
+            style={{ color: '#808080' }}
+          >
+            <span
+              className="font-bold text-sm"
+              style={{ color: '#0a72ef' }}
+            >
+              {contributionsCount.toLocaleString()}
+            </span>
+            {' '}contributions in the last year
+          </p>
+        )}
+      </div>
+      <div
+        ref={scrollRef}
+        className="p-4 rounded-lg overflow-x-auto"
+        style={{ boxShadow: 'var(--card-shadow)' }}
+      >
+        <img
+          src="https://ghchart.rshah.org/0a72ef/CUinspace233"
+          alt="GitHub contribution chart for CUinspace233"
+          className="w-full min-w-[600px]"
+          style={{ imageRendering: 'crisp-edges' }}
+        />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Splits ContributionsChart into a server component (data fetching) and
client component (scroll behaviour). The server component fetches
GitHub's user contributions page, parses data-count attributes, and
passes the yearly total to the client. Falls back gracefully when the
fetch fails or returns no data.

https://claude.ai/code/session_01RJaNNydRwazg3ykcMaFzen